### PR TITLE
Vakenbolt/more tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ Start by creating a training data set that is used by the classifier to analyze 
 
 Diagnosis Question 1 | Diagnosis Question 2 | Diagnosis
 ------------ | ------------- | -------------
-Sympton 1 | Sympton 2 | Diagnosis A
-Sympton 1 | Sympton 3 | Diagnosis B
-Sympton 4 | Sympton 5 | Diagnosis C
-Sympton 1 | Sympton 3 | Diagnosis D
-Sympton 1 | Sympton 5 | Diagnosis E
+Symptom1 | Symptom2 | DiagnosisA
+Symptom1 | Symptom1 | DiagnosisB
+Symptom1 | Symptom5 | DiagnosisC
+Symptom1 | Symptom3 | DiagnosisD
+Symptom5 | Symptom3 | DiagnosisE
+Symptom1 | Symptom4 | DiagnosisB
+Symptom1 | Symptom1 | DiagnosisC
+Symptom2 | Symptom3 | DiagnosisC
 
 Use a data class(if needed, a regular class will also work) to create a typed representation of a row in the training data set. The resulting class must implement the `DecisionTreeClassifierDataRow` interface. The `classification` method returns the value of the classification column.
 >In the example below, the classification column is the `diagnosis` field whose type is the `Diagnosis` enum.
@@ -42,19 +45,19 @@ List<DecisionTreeClassifierDataRow<Diagnosis>> = listOf(DataRow(Symptom1, Sympto
 
 The predicate's or _questions_ used to analyze the training data is done with the `PredicateFunction` class which takes a label and lambda as the predicate function.
 ```kotlin
-val q1: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = "q1") {
-    it.diagnosisSymptom1 == Symptom1 || it.diagnosisSymptom2 == Symptom1
+val q1: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = QuestionLabels.Q1) {
+    it.diagnosisSymptom1 == Symptom1 || it.diagnosisSymptom2 == Symptom5
 }
-val q2: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = "q2") {
-    it.diagnosisSymptom1 == Symptom2 || it.diagnosisSymptom2 == Symptom2
+val q2: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = QuestionLabels.Q2) {
+    it.diagnosisSymptom1 == Symptom1 || it.diagnosisSymptom2 == Symptom3
 }
-val q3: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = "q3") {
+val q3: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = QuestionLabels.Q3) {
     it.diagnosisSymptom1 == Symptom3 || it.diagnosisSymptom2 == Symptom3
 }
-val q4: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = "q4") {
+val q4: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = QuestionLabels.Q4) {
     it.diagnosisSymptom1 == Symptom4 || it.diagnosisSymptom2 == Symptom4
 }
-val q5: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = "q5") {
+val q5: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = QuestionLabels.Q5) {
     it.diagnosisSymptom1 == Symptom5 || it.diagnosisSymptom2 == Symptom5
 }
 ```
@@ -70,31 +73,33 @@ val classifier: DecisionTreeClassifier<Diagnosis> = DecisionTreeClassifier(
 Here is a sample list of data provided to the classifier for analysis.
 ```kotlin
 val data: List<DataRow<Diagnosis>> = listOf(
-    DataRow(Symptom1, Symptom2),
-    DataRow(Symptom1, Symptom3),
-    DataRow(Symptom2, Symptom5),
-    DataRow(Symptom3, Symptom1),
-    DataRow(Symptom2, Symptom5)
-)
+    DataRow(Symptom1, Symptom2, DiagnosisA),
+    DataRow(Symptom1, Symptom1, DiagnosisB),
+    DataRow(Symptom1, Symptom5, DiagnosisC),
+    DataRow(Symptom1, Symptom3, DiagnosisD),
+    DataRow(Symptom5, Symptom3, DiagnosisE),
+    DataRow(Symptom1, Symptom4, DiagnosisB),
+    DataRow(Symptom1, Symptom1, DiagnosisC),
+    DataRow(Symptom2, Symptom3, DiagnosisC))
 ```
 
 To evaluate and retrieve the classification for a _row_ of data.
+```kotlin
+classifier.evaluate(data[2])
+```
+
+Returns:
+```
+DiagnosisC
+```
+
+
+In this example, the response from the classifier will either `DiagnosisA`, `DiagnosisB` or `DiagnosisC` because the provided questions associated with the given training data could not be partitioned further.
 ```kotlin
 classifier.evaluate(data.first())
 ```
 
 Returns:
-```kotlin
-DiagnosisA
 ```
-
-
-In this example, the response from the classifier will either `DiagnosisB` or `DiagnosisD` because the provided questions associated with the given training data could not be partitioned further.
-```kotlin
-classifier.evaluate(data[3])
-```
-
-Returns:
-```kotlin
-DiagnosisB or DiagnosisD
+DiagnosisA, DiagnosisB or DiagnosisC
 ```

--- a/README.md
+++ b/README.md
@@ -37,10 +37,15 @@ data class DataRow<T>(
 The training data is created as a `List` of objects that implement the `DecisionTreeClassifierDataRow<T>` interface where `<T>` indicates the type associated with the classification column in the training model.
 ```kotlin
 List<DecisionTreeClassifierDataRow<Diagnosis>> = listOf(DataRow(Symptom1, Symptom2, DiagnosisA),
-                                                        DataRow(Symptom1, Symptom3, DiagnosisB),
-                                                        DataRow(Symptom4, Symptom5, DiagnosisC),
+                                                        DataRow(Symptom1, Symptom1, DiagnosisB),
+                                                        DataRow(Symptom1, Symptom5, DiagnosisC),
                                                         DataRow(Symptom1, Symptom3, DiagnosisD),
-                                                        DataRow(Symptom1, Symptom5, DiagnosisE)
+                                                        DataRow(Symptom5, Symptom3, DiagnosisE),
+                                                        DataRow(Symptom1, Symptom4, DiagnosisB),
+                                                        DataRow(Symptom1, Symptom1, DiagnosisC),
+                                                        DataRow(Symptom2, Symptom3, DiagnosisC))
+                                                        
+                                                        
 ```
 
 The predicate's or _questions_ used to analyze the training data is done with the `PredicateFunction` class which takes a label and lambda as the predicate function.
@@ -73,14 +78,8 @@ val classifier: DecisionTreeClassifier<Diagnosis> = DecisionTreeClassifier(
 Here is a sample list of data provided to the classifier for analysis.
 ```kotlin
 val data: List<DataRow<Diagnosis>> = listOf(
-    DataRow(Symptom1, Symptom2, DiagnosisA),
-    DataRow(Symptom1, Symptom1, DiagnosisB),
-    DataRow(Symptom1, Symptom5, DiagnosisC),
-    DataRow(Symptom1, Symptom3, DiagnosisD),
-    DataRow(Symptom5, Symptom3, DiagnosisE),
-    DataRow(Symptom1, Symptom4, DiagnosisB),
-    DataRow(Symptom1, Symptom1, DiagnosisC),
-    DataRow(Symptom2, Symptom3, DiagnosisC))
+    DataRow(Symptom1, Symptom2),
+    DataRow(Symptom1, Symptom1))
 ```
 
 To evaluate and retrieve the classification for a _row_ of data.

--- a/src/main/kotlin/io/samuelagesilas/DecisionTreeClassifier.kt
+++ b/src/main/kotlin/io/samuelagesilas/DecisionTreeClassifier.kt
@@ -5,41 +5,41 @@ import kotlin.math.pow
 
 /**
  * Main class for the [DecisionTreeClassifier] where [T] indicates the type associated with the classification column
- * in the training model.
- * @param trainingModel: The [List] of[DecisionTreeClassifierDataRow]'s making up the training model used to build the decision
- * tree.
- * @param predicateFunctions: The [List] of [PredicateFunction]'s used to query the training model.
+ * in the training data.
+ * @param trainingData: The [List] of[DecisionTreeClassifierDataRow]'s making up the training data used to build the
+ * decision tree.
+ * @param predicateFunctions: The [List] of [PredicateFunction]'s used to query the training data.
  */
-class DecisionTreeClassifier<T>(internal val trainingModel: List<DecisionTreeClassifierDataRow<T>>,
+class DecisionTreeClassifier<T>(internal val trainingData: List<DecisionTreeClassifierDataRow<T>>,
                                 private val predicateFunctions: List<PredicateFunction<*>>) {
 
     /**
-     * The calculated Gini impurity for the given [trainingModel].
+     * The calculated Gini impurity for the given [trainingData].
      */
-    val rootGiniImpurity: Double = this.calculateGiniImpurity(trainingModel)
+    val rootGiniImpurity: Double = this.calculateGiniImpurity(trainingData)
 
     /**
      * [List] associated to the list of predicate functions sorted in descending order by information gain.
      */
-    val sortedPredicates: List<Predicate<T>> = this.calculateInformationGain(rows = trainingModel)
+    val sortedPredicates: List<Predicate<T>> = this.calculateInformationGain(rows = trainingData)
         .sortedByDescending { it.informationGain }
 
     private var decisionTree: PredicateNode<T>
 
-    private fun calculateGiniImpurity(trainingModelRows: List<DecisionTreeClassifierDataRow<T>>): Double {
+    private fun calculateGiniImpurity(trainingDataRows: List<DecisionTreeClassifierDataRow<T>>): Double {
         val classificationCounts: MutableMap<T, Int> = mutableMapOf()
-        val distinctClasses: List<DecisionTreeClassifierDataRow<T>> = trainingModelRows.distinctBy {
+        val distinctClasses: List<DecisionTreeClassifierDataRow<T>> = trainingDataRows.distinctBy {
             it.classification()
         }
-        distinctClasses.forEach { trainingModelRow: DecisionTreeClassifierDataRow<T> ->
-            classificationCounts[trainingModelRow.classification()!!] =
-                trainingModelRows.count { m: DecisionTreeClassifierDataRow<T> ->
-                    m.classification()!!.toString() == trainingModelRow.classification().toString()
+        distinctClasses.forEach { trainingDataRow: DecisionTreeClassifierDataRow<T> ->
+            classificationCounts[trainingDataRow.classification()!!] =
+                trainingDataRows.count { m: DecisionTreeClassifierDataRow<T> ->
+                    m.classification()!!.toString() == trainingDataRow.classification().toString()
                 }
         }
         val probabilities: MutableList<Double> = mutableListOf()
         classificationCounts.forEach { _, v ->
-            probabilities.add((v.toDouble() / trainingModelRows.size).pow(2))
+            probabilities.add((v.toDouble() / trainingDataRows.size).pow(2))
         }
         return 1 - probabilities.sum()
     }
@@ -65,9 +65,9 @@ class DecisionTreeClassifier<T>(internal val trainingModel: List<DecisionTreeCla
         @Suppress("UNCHECKED_CAST")
         val p = predicateFunctions as List<PredicateFunction<DecisionTreeClassifierDataRow<T>>>
         p.iterator().forEach { predicateFunction: PredicateFunction<DecisionTreeClassifierDataRow<T>> ->
-            val result: PredicateResult<T> = evaluatePredicate(predicateFunction, this.trainingModel)
-            val leftGiniImpurity: Double = this.calculateGiniImpurity(trainingModelRows = result.left)
-            val rightGiniImpurity: Double = this.calculateGiniImpurity(trainingModelRows = result.right)
+            val result: PredicateResult<T> = evaluatePredicate(predicateFunction, this.trainingData)
+            val leftGiniImpurity: Double = this.calculateGiniImpurity(trainingDataRows = result.left)
+            val rightGiniImpurity: Double = this.calculateGiniImpurity(trainingDataRows = result.right)
 
             //weighted average of each question
             val avgImpurity: Double = (result.left.size.toDouble() / rows.size) * leftGiniImpurity +
@@ -137,7 +137,7 @@ class DecisionTreeNodeBuilder<T>(private val decisionTreeClassifier: DecisionTre
     private fun processNode(rootNode: PredicateNode<T>,
                             childNodes: LinkedList<PredicateNode<T>>,
                             evaluatePredicate: (p: PredicateFunction<DecisionTreeClassifierDataRow<T>>,
-                                                trainingModel: List<DecisionTreeClassifierDataRow<T>>) -> PredicateResult<T>) {
+                                                trainingData: List<DecisionTreeClassifierDataRow<T>>) -> PredicateResult<T>) {
         if (rootNode.nodeResult!!.size == 1) return
         rootNode.result = evaluatePredicate.invoke(rootNode.predicate.predicateFunction,
                                                    rootNode.nodeResult!!
@@ -164,7 +164,7 @@ class DecisionTreeNodeBuilder<T>(private val decisionTreeClassifier: DecisionTre
         val childNodes: LinkedList<PredicateNode<T>> = LinkedList()
         val rootNode: PredicateNode<T> = PredicateNode(predicate = this.sortedPredicates.first(),
                                                        predicateIndex = 0,
-                                                       nodeResult = this.decisionTreeClassifier.trainingModel)
+                                                       nodeResult = this.decisionTreeClassifier.trainingData)
         processNode(rootNode, childNodes, decisionTreeClassifier::evaluatePredicate)
         while (childNodes.size > 0) {
             processNode(childNodes.poll(), childNodes, decisionTreeClassifier::evaluatePredicate)
@@ -175,13 +175,13 @@ class DecisionTreeNodeBuilder<T>(private val decisionTreeClassifier: DecisionTre
 
 
 /**
- * Interface for any data type used as a row in a training model.
- * [T] indicates the type associated with the classification column in the training model.
+ * Interface for any data type used as a row in a training data.
+ * [T] indicates the type associated with the classification column in the training data.
  */
 abstract class DecisionTreeClassifierDataRow<T> {
 
     /**
-     * Returns the typed value associated with the classification column in the training model.
+     * Returns the typed value associated with the classification column in the training data.
      */
     open fun classification(): T? {
         return null

--- a/src/main/kotlin/io/samuelagesilas/DecisionTreeClassifier.kt
+++ b/src/main/kotlin/io/samuelagesilas/DecisionTreeClassifier.kt
@@ -28,10 +28,11 @@ class DecisionTreeClassifier<T>(internal val trainingData: List<DecisionTreeClas
 
     private fun calculateGiniImpurity(trainingDataRows: List<DecisionTreeClassifierDataRow<T>>): Double {
         val classificationCounts: MutableMap<T, Int> = mutableMapOf()
-        val distinctClasses: List<DecisionTreeClassifierDataRow<T>> = trainingDataRows.distinctBy {
+        val distinctClassification: List<DecisionTreeClassifierDataRow<T>> = trainingDataRows.distinctBy {
             it.classification()
         }
-        distinctClasses.forEach { trainingDataRow: DecisionTreeClassifierDataRow<T> ->
+        //check for the number of times a classification appears in the trainingDataRows list.
+        distinctClassification.forEach { trainingDataRow: DecisionTreeClassifierDataRow<T> ->
             classificationCounts[trainingDataRow.classification()!!] =
                 trainingDataRows.count { m: DecisionTreeClassifierDataRow<T> ->
                     m.classification()!!.toString() == trainingDataRow.classification().toString()

--- a/src/test/kotlin/io/samuelagesilas/DecisionTreeClassifierTest.kt
+++ b/src/test/kotlin/io/samuelagesilas/DecisionTreeClassifierTest.kt
@@ -1,26 +1,29 @@
 package io.samuelagesilas
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import kotlin.math.pow
 
 class DecisionTreeClassifierTest {
     @Test
-    fun `test for correct rootGiniImpurity`() {
+    fun `test evaluate method`() {
         val data: List<DataRow<Diagnosis>> = listOf(DataRow(Symptom.Symptom1, Symptom.Symptom2),
                                                     DataRow(Symptom.Symptom1, Symptom.Symptom3),
                                                     DataRow(Symptom.Symptom2, Symptom.Symptom5),
                                                     DataRow(Symptom.Symptom3, Symptom.Symptom1),
                                                     DataRow(Symptom.Symptom2, Symptom.Symptom5)
         )
-        with(classifier.evaluate(listOf(data.first(), data[2]))) {
-            assertEquals(this[0], Diagnosis.DiagnosisA)
-            assertEquals(this[1], Diagnosis.DiagnosisC)
+        for (i in 1..100) {
+
+            with(classifier.evaluate(listOf(data.first(), data[2]))) {
+                assertTrue(this[0] == Diagnosis.DiagnosisA
+                                   || this[0] == Diagnosis.DiagnosisB
+                                   || this[0] == Diagnosis.DiagnosisC)
+                assertEquals(this[1], Diagnosis.DiagnosisC)
+            }
+            assertEquals(Diagnosis.DiagnosisC, classifier.evaluate(data[2]))
+            assertEquals(Diagnosis.DiagnosisC, classifier.evaluate(data[3]))
+            assertEquals(Diagnosis.DiagnosisC, classifier.evaluate(data[4]))
         }
-        assertEquals(Diagnosis.DiagnosisC, classifier.evaluate(data[2]))
-        with(classifier.evaluate(data[3])) {
-            assertTrue(this == Diagnosis.DiagnosisB || this == Diagnosis.DiagnosisD)
-        }
-        assertEquals(Diagnosis.DiagnosisC, classifier.evaluate(data[4]))
     }
 }

--- a/src/test/kotlin/io/samuelagesilas/DecisionTreeClassifierTest.kt
+++ b/src/test/kotlin/io/samuelagesilas/DecisionTreeClassifierTest.kt
@@ -1,0 +1,26 @@
+package io.samuelagesilas
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import kotlin.math.pow
+
+class DecisionTreeClassifierTest {
+    @Test
+    fun `test for correct rootGiniImpurity`() {
+        val data: List<DataRow<Diagnosis>> = listOf(DataRow(Symptom.Symptom1, Symptom.Symptom2),
+                                                    DataRow(Symptom.Symptom1, Symptom.Symptom3),
+                                                    DataRow(Symptom.Symptom2, Symptom.Symptom5),
+                                                    DataRow(Symptom.Symptom3, Symptom.Symptom1),
+                                                    DataRow(Symptom.Symptom2, Symptom.Symptom5)
+        )
+        with(classifier.evaluate(listOf(data.first(), data[2]))) {
+            assertEquals(this[0], Diagnosis.DiagnosisA)
+            assertEquals(this[1], Diagnosis.DiagnosisC)
+        }
+        assertEquals(Diagnosis.DiagnosisC, classifier.evaluate(data[2]))
+        with(classifier.evaluate(data[3])) {
+            assertTrue(this == Diagnosis.DiagnosisB || this == Diagnosis.DiagnosisD)
+        }
+        assertEquals(Diagnosis.DiagnosisC, classifier.evaluate(data[4]))
+    }
+}

--- a/src/test/kotlin/io/samuelagesilas/DecisionTreeClassifierTest.kt
+++ b/src/test/kotlin/io/samuelagesilas/DecisionTreeClassifierTest.kt
@@ -11,10 +11,8 @@ class DecisionTreeClassifierTest {
                                                     DataRow(Symptom.Symptom1, Symptom.Symptom3),
                                                     DataRow(Symptom.Symptom2, Symptom.Symptom5),
                                                     DataRow(Symptom.Symptom3, Symptom.Symptom1),
-                                                    DataRow(Symptom.Symptom2, Symptom.Symptom5)
-        )
+                                                    DataRow(Symptom.Symptom2, Symptom.Symptom5))
         for (i in 1..100) {
-
             with(classifier.evaluate(listOf(data.first(), data[2]))) {
                 assertTrue(this[0] == Diagnosis.DiagnosisA
                                    || this[0] == Diagnosis.DiagnosisB

--- a/src/test/kotlin/io/samuelagesilas/TrainingModel.kt
+++ b/src/test/kotlin/io/samuelagesilas/TrainingModel.kt
@@ -35,29 +35,39 @@ object QuestionLabels {
     const val Q5 = "Question 5"
 }
 
-val trainingModel: List<DecisionTreeClassifierDataRow<Diagnosis>> = listOf(DataRow(
-    Symptom1,
-    Symptom2,
-    DiagnosisA
-),
-                                                                                                               DataRow(
-                                                                                                                   Symptom1,
-                                                                                                                   Symptom3,
-                                                                                                                   DiagnosisB
-                                                                                                               ),
-                                                                                                               DataRow(
-                                                                                                                   Symptom4,
-                                                                                                                   Symptom5,
-                                                                                                                   DiagnosisC
-                                                                                                               ),
-                                                                                                               DataRow(
-                                                                                                                   Symptom1,
-                                                                                                                   Symptom3,
-                                                                                                                   DiagnosisD
-                                                                                                               ),
-                                                                                                               DataRow(
-                                                                                                                   Symptom1,
-                                                                                                                   Symptom5,
-                                                                                                                   DiagnosisE
-                                                                                                               )
+val trainingModel: List<DecisionTreeClassifierDataRow<Diagnosis>> = listOf(DataRow(Symptom1, Symptom2, DiagnosisA),
+                                                                           DataRow(Symptom1, Symptom1, DiagnosisB),
+                                                                           DataRow(Symptom1, Symptom5, DiagnosisC),
+                                                                           DataRow(Symptom1, Symptom3, DiagnosisD),
+                                                                           DataRow(Symptom5, Symptom3, DiagnosisE),
+                                                                           DataRow(Symptom1, Symptom4, DiagnosisB),
+                                                                           DataRow(Symptom1, Symptom1, DiagnosisC),
+                                                                           DataRow(Symptom2, Symptom3, DiagnosisC)
 )
+
+object Questions {
+    val q1: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = QuestionLabels.Q1) {
+        it.diagnosisSymptom1 == Symptom1 || it.diagnosisSymptom2 == Symptom5
+    }
+    val q2: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = QuestionLabels.Q2) {
+        it.diagnosisSymptom1 == Symptom1 || it.diagnosisSymptom2 == Symptom3
+    }
+    val q3: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = QuestionLabels.Q3) {
+        it.diagnosisSymptom1 == Symptom3 || it.diagnosisSymptom2 == Symptom3
+    }
+    val q4: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = QuestionLabels.Q4) {
+        it.diagnosisSymptom1 == Symptom4 || it.diagnosisSymptom2 == Symptom4
+    }
+    val q5: PredicateFunction<DataRow<Diagnosis>> = PredicateFunction(label = QuestionLabels.Q5) {
+        it.diagnosisSymptom1 == Symptom5 || it.diagnosisSymptom2 == Symptom5
+    }
+
+    val predicates: List<PredicateFunction<DataRow<Diagnosis>>> = listOf(Questions.q1,
+                                                                         Questions.q2,
+                                                                         Questions.q3,
+                                                                         Questions.q4,
+                                                                         Questions.q5)
+}
+
+
+val classifier: DecisionTreeClassifier<Diagnosis> = DecisionTreeClassifier(trainingModel, Questions.predicates)

--- a/src/test/kotlin/io/samuelagesilas/TrainingModel.kt
+++ b/src/test/kotlin/io/samuelagesilas/TrainingModel.kt
@@ -5,11 +5,14 @@ import io.samuelagesilas.Symptom.*
 
 /*
 DiagQuestion A   DiagQuestion B    Diagnosis
-Sympton 1        Sympton 2         Diagnosis A
-Sympton 1        Sympton 3         Diagnosis B
-Sympton 4        Sympton 5         Diagnosis C
-Sympton 1        Sympton 3         Diagnosis D
-Sympton 1        Sympton 5         Diagnosis E
+Symptom1         Symptom2          DiagnosisA
+Symptom1         Symptom1          DiagnosisB
+Symptom1         Symptom5          DiagnosisC
+Symptom1         Symptom3          DiagnosisD
+Symptom5         Symptom3          DiagnosisE
+Symptom1         Symptom4          DiagnosisB
+Symptom1         Symptom1          DiagnosisC
+Symptom2         Symptom3          DiagnosisC
 */
 enum class Symptom {
     Symptom1,

--- a/src/test/kotlin/io/samuelagesilas/TrainingModelTest.kt
+++ b/src/test/kotlin/io/samuelagesilas/TrainingModelTest.kt
@@ -1,7 +1,7 @@
 package io.samuelagesilas
 
 import io.samuelagesilas.Diagnosis.*
-import io.samuelagesilas.Symptom.*
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -19,95 +19,95 @@ data class DataRow<T>(val diagnosisSymptom1: Symptom,
 class TrainingModelTest {
 
     @Test
-    fun `test for correct training data`() {
-        with(trainingModel[0] as DataRow) {
-            assertEquals(Symptom1, this.diagnosisSymptom1)
-            assertEquals(Symptom2, this.diagnosisSymptom2)
-            assertEquals(DiagnosisA, this.classification())
-        }
-        with(trainingModel[1] as DataRow) {
-            assertEquals(Symptom1, this.diagnosisSymptom1)
-            assertEquals(Symptom3, this.diagnosisSymptom2)
-            assertEquals(DiagnosisB, this.classification())
-        }
-        with(trainingModel[2] as DataRow) {
-            assertEquals(Symptom4, this.diagnosisSymptom1)
-            assertEquals(Symptom5, this.diagnosisSymptom2)
-            assertEquals(DiagnosisC, this.classification())
-        }
-        with(trainingModel[3] as DataRow) {
-            assertEquals(Symptom1, this.diagnosisSymptom1)
-            assertEquals(Symptom3, this.diagnosisSymptom2)
-            assertEquals(DiagnosisD, this.classification())
-        }
-        with(trainingModel[4] as DataRow) {
-            assertEquals(Symptom1, diagnosisSymptom1)
-            assertEquals(Symptom5, diagnosisSymptom2)
-            assertEquals(DiagnosisE, this.classification())
-        }
-
-        val q1: PredicateFunction<DataRow<Diagnosis>> =
-            PredicateFunction(label = QuestionLabels.Q1) {
-                it.diagnosisSymptom1 == Symptom1 || it.diagnosisSymptom2 == Symptom1
-            }
-        val q2: PredicateFunction<DataRow<Diagnosis>> =
-            PredicateFunction(label = QuestionLabels.Q2) {
-                it.diagnosisSymptom1 == Symptom2 || it.diagnosisSymptom2 == Symptom2
-            }
-        val q3: PredicateFunction<DataRow<Diagnosis>> =
-            PredicateFunction(label = QuestionLabels.Q3) {
-                it.diagnosisSymptom1 == Symptom3 || it.diagnosisSymptom2 == Symptom3
-            }
-        val q4: PredicateFunction<DataRow<Diagnosis>> =
-            PredicateFunction(label = QuestionLabels.Q4) {
-                it.diagnosisSymptom1 == Symptom4 || it.diagnosisSymptom2 == Symptom4
-            }
-        val q5: PredicateFunction<DataRow<Diagnosis>> =
-            PredicateFunction(label = QuestionLabels.Q5) {
-                it.diagnosisSymptom1 == Symptom5 || it.diagnosisSymptom2 == Symptom5
-            }
-
-        val p: List<PredicateFunction<DataRow<Diagnosis>>> = listOf(q1, q2, q3, q4, q5)
-        val classifier: DecisionTreeClassifier<Diagnosis> =
-            DecisionTreeClassifier(
-                trainingModel = trainingModel,
-                predicateFunctions = p
-            )
-        classifier.sortedPredicates.forEach { println("${it.predicateFunction.label}, ${it.avgImpurity}, ${it.informationGain}") }
-
-        val i: Iterator<Predicate<Diagnosis>> = classifier.sortedPredicates.iterator()
-        assertEquals(QuestionLabels.Q1, i.next().predicateFunction.label)
-        assertEquals(QuestionLabels.Q2, i.next().predicateFunction.label)
-        assertEquals(QuestionLabels.Q4, i.next().predicateFunction.label)
-        assertEquals(QuestionLabels.Q3, i.next().predicateFunction.label)
-        assertEquals(QuestionLabels.Q5, i.next().predicateFunction.label)
-
-        assertEquals(classifier.evaluate(trainingModel.first()), DiagnosisA)
-        assertEquals(classifier.evaluate(trainingModel[2]), DiagnosisC)
-
-        val data: List<DataRow<Diagnosis>> = listOf(
-            DataRow(Symptom1, Symptom2),
-            DataRow(Symptom1, Symptom3),
-            DataRow(Symptom2, Symptom5),
-            DataRow(Symptom3, Symptom1),
-            DataRow(Symptom2, Symptom5)
-        )
-        with(classifier.evaluate(listOf(data.first(), data[2]))) {
-            assertEquals(this[0], DiagnosisA)
-            assertEquals(this[1], DiagnosisC)
-        }
-        assertEquals(DiagnosisC, classifier.evaluate(data[2]))
-        with(classifier.evaluate(data[3])) {
-            assertTrue(this == DiagnosisB || this == DiagnosisD)
-        }
-        assertEquals(DiagnosisC, classifier.evaluate(data[4]))
+    fun `test for correct rootGiniImpurity`() {
         val n: Double = 1 - listOf(
-            (1.toDouble() / 5).pow(2),
-            (1.toDouble() / 5).pow(2),
-            (1.toDouble() / 5).pow(2),
-            (1.toDouble() / 5).pow(2),
-            (1.toDouble() / 5).pow(2)
+            (1.toDouble() / 8).pow(2),
+            (2.toDouble() / 8).pow(2),
+            (3.toDouble() / 8).pow(2),
+            (1.toDouble() / 8).pow(2),
+            (1.toDouble() / 8).pow(2)
         ).sum()
-        assertEquals(classifier.rootGiniImpurity, n)
+        Assertions.assertEquals(classifier.rootGiniImpurity, n)
+    }
+
+    @Test
+    fun `test for correct order of predicateFunction labels`() {
+        val i: Iterator<Predicate<Diagnosis>> = classifier.sortedPredicates.iterator()
+        with(QuestionLabels) {
+            assertEquals(this.Q4, i.next().predicateFunction.label)
+            assertEquals(this.Q3, i.next().predicateFunction.label)
+            assertEquals(this.Q1, i.next().predicateFunction.label)
+            assertEquals(this.Q5, i.next().predicateFunction.label)
+            assertEquals(this.Q2, i.next().predicateFunction.label)
+        }
+    }
+
+    @Test
+    fun `Test the avg impurity and information gain of Question 1`() {
+        val impurity = object {
+            val left: Double = 1 - listOf(
+                (1.toDouble() / 6).pow(2),
+                (2.toDouble() / 6).pow(2),
+                (2.toDouble() / 6).pow(2),
+                (1.toDouble() / 6).pow(2)
+            ).sum()
+            val right = 1 - listOf(
+                (1.toDouble() / 2).pow(2),
+                (1.toDouble() / 2).pow(2)
+            ).sum()
+        }
+        val avgImpurity = (6.toDouble() / 8) * impurity.left + (2.toDouble() / 8) * impurity.right
+        val p: Predicate<Diagnosis> = classifier.sortedPredicates.first { it.predicateFunction.label == "Question 1" }
+        assertEquals(p.avgImpurity, avgImpurity)
+        assertEquals(p.informationGain, classifier.rootGiniImpurity - avgImpurity)
+    }
+
+    @Test
+    fun `Test the avg impurity and information gain of Question 4`() {
+        val impurity = object {
+            val left: Double = 1 - ((1.toDouble() / 1).pow(2))
+            val right = 1 - listOf(
+                (1.toDouble() / 7).pow(2),
+                (1.toDouble() / 7).pow(2),
+                (3.toDouble() / 7).pow(2),
+                (1.toDouble() / 7).pow(2),
+                (1.toDouble() / 7).pow(2)
+            ).sum()
+        }
+        val avgImpurity = (1.toDouble() / 8) * impurity.left + (7.toDouble() / 8) * impurity.right
+        val p: Predicate<Diagnosis> = classifier.sortedPredicates.first { it.predicateFunction.label == "Question 4" }
+        assertEquals(p.avgImpurity, avgImpurity)
+        assertEquals(p.informationGain, classifier.rootGiniImpurity - avgImpurity)
+    }
+
+    @Test
+    fun `Test the avg impurity and information gain of Question 3`() {
+        val impurity = object {
+            val left: Double = 1 - listOf(
+                (1.toDouble() / 3).pow(2),
+                (1.toDouble() / 3).pow(2),
+                (1.toDouble() / 3).pow(2)
+            ).sum()
+            val right = 1 - listOf(
+                (1.toDouble() / 5).pow(2),
+                (2.toDouble() / 5).pow(2),
+                (2.toDouble() / 5).pow(2)
+            ).sum()
+        }
+        val avgImpurity = (3.toDouble() / 8) * impurity.left + (5.toDouble() / 8) * impurity.right
+        val p: Predicate<Diagnosis> = classifier.sortedPredicates.first { it.predicateFunction.label == "Question 3" }
+        assertEquals(p.avgImpurity, avgImpurity)
+        assertEquals(p.informationGain, classifier.rootGiniImpurity - avgImpurity)
+    }
+
+    @Test
+    fun `test training data predicates with classifier`() {
+        classifier.sortedPredicates.forEach { println("${it.predicateFunction.label}, ${it.avgImpurity}, ${it.informationGain}") }
+        for (i in 0 until 100) {
+            with(classifier.evaluate(trainingModel.first())) {
+                assertTrue(this == DiagnosisA || this == DiagnosisB || this == DiagnosisC)
+            }
+        }
+        assertEquals(classifier.evaluate(trainingModel[2]), DiagnosisC)
     }
 }

--- a/src/test/kotlin/io/samuelagesilas/TrainingModelTest.kt
+++ b/src/test/kotlin/io/samuelagesilas/TrainingModelTest.kt
@@ -103,11 +103,19 @@ class TrainingModelTest {
     @Test
     fun `test training data predicates with classifier`() {
         classifier.sortedPredicates.forEach { println("${it.predicateFunction.label}, ${it.avgImpurity}, ${it.informationGain}") }
-        for (i in 0 until 100) {
+        for (i in 1..100) {
             with(classifier.evaluate(trainingModel.first())) {
                 assertTrue(this == DiagnosisA || this == DiagnosisB || this == DiagnosisC)
             }
+            assertEquals(classifier.evaluate(trainingModel[2]), DiagnosisC)
+            assertEquals(classifier.evaluate(trainingModel[3]), DiagnosisD)
+            assertEquals(classifier.evaluate(trainingModel[4]), DiagnosisE)
+            assertEquals(classifier.evaluate(trainingModel[5]), DiagnosisB)
+            with(classifier.evaluate(trainingModel[6])) {
+                assertTrue(this == DiagnosisA || this == DiagnosisB || this == DiagnosisC)
+            }
+            assertEquals(classifier.evaluate(trainingModel[7]), DiagnosisC)
         }
-        assertEquals(classifier.evaluate(trainingModel[2]), DiagnosisC)
+
     }
 }


### PR DESCRIPTION
- `TrainingModelRow` is now `TrainingDataRow`
- Fixes broken tests as a result of a bug fix
- Adds more test to covering the validity of the training model and associated results.
- Adds tests for the `DecisionTreeClassifier` covering data _not_ in the training model
- Verifies the conditions where the decision tree needs to perform a guess.